### PR TITLE
Fix create study if exist bio_experiment

### DIFF
--- a/grails-app/controllers/fm/FmFolderController.groovy
+++ b/grails-app/controllers/fm/FmFolderController.groovy
@@ -270,7 +270,8 @@ class FmFolderController {
         folder.folderType = FolderType.STUDY.name()
         folder.parent = parentFolder
 
-        def experiment = new Experiment()
+        def experiment = Experiment.findOrCreateByAccession(params.accession)
+
         experiment.title = folder.folderName
         experiment.description = folder.description
         experiment.type = "Experiment"


### PR DESCRIPTION
If dataset uploaded with secure option, then associated row created in biomart.bio_experiment. After that is not possible to create new Study in Program explorer with this accession, because study folder creation logic tries to create new bio experiment with same study id. This fix reuses existing BIO_EXPERIMENT if it is not already associated with another study in Program Explorer.