### PR TITLE
Fix naming for field value in metadata view

### DIFF
--- a/grails-app/views/fmFolder/_folderDetail.gsp
+++ b/grails-app/views/fmFolder/_folderDetail.gsp
@@ -122,10 +122,10 @@
                                 <!-- FIXED -->
                                 <g:if test="${amTagItem.tagItemType == 'FIXED'  &&
                                               amTagItem.tagItemAttr!=null?bioDataObject?.hasProperty(amTagItem.tagItemAttr):false}" >
-                                    <g:set var="fieldValue" value="${fieldValue(bean:bioDataObject,field:amTagItem.tagItemAttr)}"/>
+                                    <g:set var="_fieldValue" value="${fieldValue(bean:bioDataObject,field:amTagItem.tagItemAttr)}"/>
                                     <g:if test="${amTagItem.tagItemSubtype == 'PICKLIST'}">
                                         <%-- Split multiple values by pipe --%>
-                                        <g:set var="terms" value="${fieldValue.split('\\|')}"/>
+                                        <g:set var="terms" value="${_fieldValue.split('\\|')}"/>
                                  
                                         <g:each in="${terms}" var="term" status="t">
                                             <g:set var="bioDataId" value="${BioData.find('from BioData where uniqueId=?',[term])?.id}"/>
@@ -141,7 +141,7 @@
                                     </g:if>
                                     <g:elseif test="${amTagItem.tagItemSubtype == 'MULTIPICKLIST'}">
                                         <%-- Split multiple values by pipe --%>
-                                        <g:set var="terms" value="${fieldValue.split('\\|')}"/>
+                                        <g:set var="terms" value="${_fieldValue.split('\\|')}"/>
                                  
                                         <g:each in="${terms}" var="term" status="t">
                                             <g:set var="bioDataId" value="${BioData.find('from BioData where uniqueId=?',[term])?.id}"/>
@@ -155,7 +155,7 @@
                                         </g:each>
                                     </g:elseif>
                                     <g:else>
-                                                ${fieldValue}
+                                                ${_fieldValue}
                                     </g:else>
                                 </g:if>
                                 <g:else>

--- a/grails-app/views/fmFolder/_metaData.gsp
+++ b/grails-app/views/fmFolder/_metaData.gsp
@@ -27,8 +27,8 @@
                             </g:if>
                             <g:elseif test="${amTagItem.tagItemSubtype == 'MULTIPICKLIST'}">
                                 <g:set var="metaDataService" bean="metaDataService"/>
-                                <g:set var="fieldValue" value="${fieldValue(bean:bioDataObject,field:amTagItem.tagItemAttr)}"/>
-                                <g:set var="displayValues" value="${metaDataService.getViewValues(fieldValue)}"/>
+                                <g:set var="_fieldValue" value="${fieldValue(bean:bioDataObject,field:amTagItem.tagItemAttr)}"/>
+                                <g:set var="displayValues" value="${metaDataService.getViewValues(_fieldValue)}"/>
                                 <g:render template="extTagSearchField" plugin="folderManagement"
                                           model="${[fieldName:amTagItem.tagItemAttr, codeTypeName:amTagItem.codeTypeName,
                                                     searchAction:'extSearch', searchController:'metaData', values:displayValues]}"/>


### PR DESCRIPTION
```gsp
<g:set var="fieldValue" value="${fieldValue(bean:bioDataObject,field:amTagItem.tagItemAttr)}"/>
```

This fragment of code uses same variable name as `fieldValue` function and it produces in some cases strange error:
<pre>
Message: No signature of method: java.lang.String.call() is applicable for argument types: (java.util.LinkedHashMap) values: [[bean:id: null; type: null; title: null; description: null; accesion: null, ...]]
Possible solutions: wait(), any(), wait(long), take(int), any(groovy.lang.Closure), each(groovy.lang.Closure)
<pre>